### PR TITLE
fix: run install/version checks from the workspace cwd

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -88,8 +88,16 @@ export class RumdlLanguageClient implements vscode.Disposable {
       // Get the best available rumdl path (bundled first, then configured/system)
       const rumdlPath = await BundledToolsManager.getBestRumdlPath(config.server.path);
 
+      // Determine working directory (workspace root or current directory).
+      // Computed before the install check so it can be used as the spawn cwd:
+      // the server is launched with this cwd, so the check must use it too or a
+      // version-manager shim (mise, asdf, …) can't resolve the project-pinned
+      // tool and the check fails even though the server would work.
+      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+      const workingDirectory = workspaceFolder?.uri.fsPath || process.cwd();
+
       // Check if rumdl is available
-      const isInstalled = await checkRumdlInstallation(rumdlPath);
+      const isInstalled = await checkRumdlInstallation(rumdlPath, workingDirectory);
       if (!isInstalled) {
         const bundledAvailable = BundledToolsManager.hasBundledTools();
         const errorMessage = bundledAvailable
@@ -103,16 +111,13 @@ export class RumdlLanguageClient implements vscode.Disposable {
       }
 
       // Get and log rumdl version
-      const version = await getRumdlVersion(rumdlPath);
+      const version = await getRumdlVersion(rumdlPath, workingDirectory);
       if (version) {
         Logger.info(`Using rumdl version: ${version}`);
       }
 
       this.statusBar.setStarting();
 
-      // Determine working directory (workspace root or current directory)
-      const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
-      const workingDirectory = workspaceFolder?.uri.fsPath || process.cwd();
       Logger.info(`Using working directory: ${workingDirectory}`);
 
       // Build server arguments (no config arguments, they go through initialization options)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
 
 export const SUPPORTED_LANGUAGE_IDS = ['markdown', 'mdx'];
 
@@ -91,7 +92,19 @@ export function showWarningMessage(
   return vscode.window.showWarningMessage(message, ...actions);
 }
 
-export async function checkRumdlInstallation(rumdlPath: string): Promise<boolean> {
+/**
+ * Resolve the working directory for a `rumdl --version` probe. Defaults to the
+ * first workspace folder so version-manager shims (mise, asdf, aqua, proto, …)
+ * resolve the project-pinned tool instead of failing outside the workspace.
+ * Returns undefined when the directory is missing so spawn inherits the parent
+ * cwd rather than throwing ENOENT.
+ */
+export function resolveCheckCwd(cwd?: string): string | undefined {
+  const candidate = cwd ?? vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+  return candidate && fs.existsSync(candidate) ? candidate : undefined;
+}
+
+export async function checkRumdlInstallation(rumdlPath: string, cwd?: string): Promise<boolean> {
   // Validate the path parameter
   if (!rumdlPath || rumdlPath.trim() === '') {
     Logger.error('checkRumdlInstallation called with empty or invalid path');
@@ -102,8 +115,9 @@ export async function checkRumdlInstallation(rumdlPath: string): Promise<boolean
 
   try {
     const { spawn } = await import('child_process');
+    const spawnCwd = resolveCheckCwd(cwd);
     return new Promise(resolve => {
-      const process = spawn(rumdlPath, ['--version'], { stdio: 'pipe' });
+      const process = spawn(rumdlPath, ['--version'], { stdio: 'pipe', cwd: spawnCwd });
       let stdout = '';
       let stderr = '';
 
@@ -152,15 +166,16 @@ export async function checkRumdlInstallation(rumdlPath: string): Promise<boolean
   }
 }
 
-export async function getRumdlVersion(rumdlPath?: string): Promise<string | null> {
+export async function getRumdlVersion(rumdlPath?: string, cwd?: string): Promise<string | null> {
   if (!rumdlPath || rumdlPath.trim() === '') {
     return null;
   }
 
   try {
     const { spawn } = await import('child_process');
+    const spawnCwd = resolveCheckCwd(cwd);
     return new Promise(resolve => {
-      const process = spawn(rumdlPath, ['--version'], { stdio: 'pipe' });
+      const process = spawn(rumdlPath, ['--version'], { stdio: 'pipe', cwd: spawnCwd });
       let stdout = '';
 
       process.stdout?.on('data', data => {


### PR DESCRIPTION
## What & why

Fixes #148.

The extension's pre-flight checks — `checkRumdlInstallation()` and `getRumdlVersion()` — spawn `rumdl --version` **without setting `cwd`**, so the child inherits the extension host's working directory (outside the workspace). Version-manager shims (mise, asdf, aqua, proto, …) resolve the *project-pinned* tool per-directory from config, so from a non-workspace cwd they can't find it and exit non-zero. The check then reports **"rumdl binary not working"** and aborts startup — even though the language **server**, which *is* launched with `cwd = workspace`, would have worked.

Example (mise on Windows, `rumdl` pinned only in the project's `mise.toml`):

```text
[INFO]  Checking rumdl installation at path: "...\mise\shims\rumdl.exe"
[DEBUG] Process exit code for "...\mise\shims\rumdl.exe": 1
[DEBUG] rumdl --version stderr: mise ERROR cannot find binary path
[ERROR] rumdl binary not working: ...\mise\shims\rumdl.exe.
```

## Change

- `checkRumdlInstallation(rumdlPath, cwd?)` and `getRumdlVersion(rumdlPath?, cwd?)` now accept an optional `cwd`, defaulting to the first workspace folder (`vscode.workspace.workspaceFolders?.[0]?.uri.fsPath`). This makes the checks consistent with how the server is spawned and fixes *any* per-directory version manager, not just mise.
- `client.ts` computes the working directory before the install check and passes it explicitly to both calls.

When there is no workspace folder, `cwd` is `undefined` and `spawn` inherits as before — no behavior change.

## Verification

Running the same shim spawn, varying only the cwd:

| cwd | result |
| --- | --- |
| workspace root | `exit 0`, `rumdl 0.2.27` |
| outside workspace (e.g. `System32`) | `exit 1`, `mise ERROR cannot find binary path` |

`npm run compile-tests`, `eslint`, and `prettier --check` pass on the changed files. Existing tests use an empty `workspaceFolders` mock, so the default resolves to `undefined` and behavior is unchanged.
